### PR TITLE
Set default username to None

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A SAML/ECP authentication handler for python-requests.
 
+## Release status
+
+[![PyPI version](https://badge.fury.io/py/requests-ecp.svg)](http://badge.fury.io/py/requests-ecp)
+[![Conda version](https://img.shields.io/conda/vn/conda-forge/requests-ecp.svg)](https://anaconda.org/conda-forge/requests-ecp/)  
+[![DOI](https://zenodo.org/badge/238942798.svg)](https://zenodo.org/badge/latestdoi/238942798)
+[![License](https://img.shields.io/pypi/l/requests-ecp.svg)](https://choosealicense.com/licenses/gpl-3.0/)
+![Supported Python versions](https://img.shields.io/pypi/pyversions/requests-ecp.svg)
+
 ## Development status
 
 [![Travis](https://img.shields.io/travis/com/duncanmmacleod/requests-ecp/master?label=Unix%20%28conda%29&logo=travis)](https://travis-ci.com/duncanmmacleod/requests-ecp)

--- a/requests_ecp.py
+++ b/requests_ecp.py
@@ -72,7 +72,7 @@ def _get_xml_attribute(xdata, path):
 def _prompt_username_password(host, username=None):
     """Prompt for a username and password from the console
     """
-    if username is None:
+    if not username:
         username = input("Enter username for {0}: ".format(host))
     password = getpass(
         "Enter password for {0!r} on {1}: ".format(username, host),
@@ -86,8 +86,8 @@ class HTTPECPAuth(requests_auth.AuthBase):
             idp,
             force_auth=False,
             kerberos=False,
-            username=False,
-            password=False,
+            username=None,
+            password=None,
     ):
         #: Address of Identity Provider ECP endpoint.
         self.idp = idp


### PR DESCRIPTION
This PR updates the default username in `HTTPECPAuth` to `None` instead of `False`.