### PR TITLE
Remove universal tag for bdist_wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,7 @@
 ; -- build
 
 [metadata]
-license_file = LICENSE
-
-[bdist_wheel]
-universal = 1
+license_files = LICENSE
 
 ; -- tools
 


### PR DESCRIPTION
This PR removes the `universal=1` configuration option for `bdist_wheel`, which isn't appropriate since we don't support python2 any more.

This also updates the metadata `license_files` option in the same `setup.cfg` file.