### PR TITLE
Dump response from initial redirect

### DIFF
--- a/requests_ecp/__init__.py
+++ b/requests_ecp/__init__.py
@@ -140,6 +140,7 @@ class HTTPECPAuth(requests_auth.AuthBase):
             extract_cookies_to_jar(session.cookies, resp.request, resp.raw)
 
     def _authenticate_response(self, response, endpoint=None, **kwargs):
+        response.raw.read()
         response.raw.release_conn()
         return self._authenticate(
             response.connection,


### PR DESCRIPTION
This PR modifies fixes a bug whereby the initial redirect is detected, but the response isn't actually read, which can lead to `ResponseNotReady` errors when reusing the same connection for the authentication.