### PR TITLE
Read version as attr in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 
 [metadata]
 name = requests-ecp
+version = attr: requests_ecp.__version__
 author = Duncan Macleod
 author_email = duncan.macleod@ligo.org
 license = GPL-3.0-or-later

--- a/setup.py
+++ b/setup.py
@@ -19,31 +19,8 @@
 """Build configuration for requests_ecp
 """
 
-import re
-from pathlib import Path
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 from setuptools import setup
 
-__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
-
-
-def find_version(path, varname="__version__"):
-    """Parse the version metadata in the given file.
-    """
-    with Path(path).open('r') as fobj:
-        version_file = fobj.read()
-    version_match = re.search(
-        r"^{0} = ['\"]([^'\"]*)['\"]".format(varname),
-        version_file,
-        re.M,
-    )
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
-
-
-# this function only manually specifies things that aren't
-# supported by setup.cfg (as of setuptools-30.3.0)
-setup(
-    version=find_version(Path("requests_ecp") / "__init__.py"),
-)
+setup()


### PR DESCRIPTION
This PR trivialises the `setup.py` script by moving the last remaining metadata attribute over to `setup.cfg`.

This _may_ require a minimum version bump for `setuptools` >= 46.4.0 but I'm not sure, so I haven't changed it.