### PR TITLE
Record total elapsed time for auth loop

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,15 +2,18 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-  configuration: docs/conf.py
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
 
 conda:
   environment: docs/rtd-environment.yml
+
+sphinx:
+  configuration: docs/conf.py
 
 python:
   install:

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends:
  python3-all,
  python3-lxml,
  python3-pytest,
- python3-requests,
+ python3-requests (>= 2.14.0),
  python3-requests-gssapi (>= 1.2.2) | python3-requests-kerberos (>= 0.9.0),
  python3-requests-mock,
  python3-setuptools (>= 30.3.0),
@@ -26,7 +26,7 @@ Depends:
  ${misc:Depends},
  ${python3:Depends},
  python3-lxml,
- python3-requests,
+ python3-requests (>= 2.14.0),
  python3-requests-gssapi (>= 1.2.2) | python3-requests-kerberos (>= 0.9.0),
 Description: SAML/ECP authentication handler for Requests
  requests-ecp adds optional SAML/ECP authentication support

--- a/requests-ecp.spec
+++ b/requests-ecp.spec
@@ -24,7 +24,7 @@ BuildRequires: python-rpm-macros
 BuildRequires: /usr/bin/python3
 BuildRequires: python3-rpm-macros
 BuildRequires: python%{python3_pkgversion}-lxml
-BuildRequires: python%{python3_pkgversion}-requests
+BuildRequires: python%{python3_pkgversion}-requests >= 2.14.0
 BuildRequires: python%{python3_pkgversion}-requests-gssapi >= 1.2.2
 BuildRequires: python%{python3_pkgversion}-setuptools >= 30.3.0
 %if 0%{?rhel} == 0 || 0%{?rhel} >= 8
@@ -42,7 +42,7 @@ for the Requests Python library.
 %package -n python%{python3_pkgversion}-%{name}
 Summary: %{summary}
 Requires: python%{python3_pkgversion}-lxml
-Requires: python%{python3_pkgversion}-requests
+Requires: python%{python3_pkgversion}-requests >= 2.14.0
 Requires: python%{python3_pkgversion}-requests-gssapi >= 1.2.2
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
 %description -n python%{python3_pkgversion}-%{name}

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ setup_requires =
 	setuptools >= 30.3.0
 install_requires =
 	lxml
-	requests
+	requests >= 2.14.0
 
 [options.extras_require]
 kerberos =


### PR DESCRIPTION
This PR suggests an idea to record the total elapsed time for an auth loop as the `elapsed` record for the final request. This is sort of terrible because it includes the time for other requests.

Ideally requests (the library) would preserve the history propagated by requests_ecp so that the true total would just be the sum of all of the requests.