### PR TITLE
Fix specification of python3 in spec file

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -357,9 +357,9 @@ jobs:
           # print contents of packages
           for rpmf in *.rpm; do
               echo "===== ${rpmf}"
-              rpm -qlp "${rpmf}"
+              rpm -qp --info "${rpmf}"
               echo "Files:"
-              rpm -qip "${rpmf}"
+              rpm -qp --list "${rpmf}"
               echo "Provides:"
               rpm -qp --provides "${rpmf}"
               echo "Requires:"

--- a/requests-ecp.spec
+++ b/requests-ecp.spec
@@ -21,8 +21,9 @@ Version:   %{version}
 
 BuildRequires: python-srpm-macros
 BuildRequires: python-rpm-macros
-BuildRequires: /usr/bin/python3
 BuildRequires: python3-rpm-macros
+
+BuildRequires: %{__python3}
 BuildRequires: python%{python3_pkgversion}-lxml
 BuildRequires: python%{python3_pkgversion}-requests
 BuildRequires: python%{python3_pkgversion}-requests-gssapi >= 1.2.2

--- a/requests-ecp.spec
+++ b/requests-ecp.spec
@@ -23,7 +23,7 @@ BuildRequires: python-srpm-macros
 BuildRequires: python-rpm-macros
 BuildRequires: python3-rpm-macros
 
-BuildRequires: %{__python3}
+BuildRequires: python%{python3_pkgversion}-devel
 BuildRequires: python%{python3_pkgversion}-lxml
 BuildRequires: python%{python3_pkgversion}-requests
 BuildRequires: python%{python3_pkgversion}-requests-gssapi >= 1.2.2


### PR DESCRIPTION
This PR fixes the specification of the Python executable in the spec file. We need the platform python, not whatever we can get from `/usr/bin/python3`.