### PR TITLE
Update docs to use furo theme and sphinx-design

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-lts-latest"
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-latest"
 
 conda:
   environment: docs/rtd-environment.yml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ from requests_ecp import __version__ as requests_ecp_version
 # -- Project information -----------------------------------------------------
 
 project = 'requests-ecp'
-copyright = '2020, Cardiff University'
+copyright = '2020-2024, Cardiff University'
 author = 'Duncan Macleod'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx_automodapi.automodapi",
-    "sphinx_panels",
+    "sphinx_design",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'furo'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -67,7 +67,7 @@ html_theme = 'sphinx_rtd_theme'
 #html_static_path = ['_static']
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'monokai'
+#pygments_style = 'monokai'
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,68 +26,69 @@
 Installation
 ============
 
-.. tabbed:: Conda
+.. tab-set::
+    .. tab-item:: Conda
 
-    .. code-block:: bash
+        .. code-block:: bash
 
-        conda install -c conda-forge requests-ecp
+            conda install -c conda-forge requests-ecp
 
-    The conda package includes the optional Kerberos Auth plugin
-    from ``requests-gssapi``, which in turn ensures that a working
-    GSSAPI implementation is installed.
+        The conda package includes the optional Kerberos Auth plugin
+        from ``requests-gssapi``, which in turn ensures that a working
+        GSSAPI implementation is installed.
 
-    Installing with Conda (or Mamba) is the recommended installation
-    method for `requests-ecp`.
+        Installing with Conda (or Mamba) is the recommended installation
+        method for `requests-ecp`.
 
-.. tabbed:: Debian Linux
+    .. tab-item:: Debian Linux
 
-    .. code-block:: bash
+        .. code-block:: bash
 
-        apt-get install python3-requests-ecp
+            apt-get install python3-requests-ecp
 
-    See the IGWN Computing Guide software repositories entry for
-    `Debian <https://computing.docs.ligo.org/guide/software/debian/>`__
-    for instructions on how to configure the required
-    IGWN Debian repositories.
+        See the IGWN Computing Guide software repositories entry for
+        `Debian <https://computing.docs.ligo.org/guide/software/debian/>`__
+        for instructions on how to configure the required
+        IGWN Debian repositories.
 
-.. tabbed:: Pip
+    .. tab-item:: Pip
 
-    .. code-block:: bash
+        .. code-block:: bash
 
-        python -m pip install requests-ecp
+            python -m pip install requests-ecp
 
-    .. admonition:: Default ``pip install`` doesn't include Kerberos Auth support
+        .. admonition:: Default ``pip install`` doesn't include Kerberos Auth support
 
-       By default ``pip install requests-ecp`` does not bundle
-       Kerberos auth support.
-       This is provided by the
-       `requests-gssapi <https://github.com/pythongssapi/requests-gssapi>`__
-       package, which in turn relies on a working installation of GSSAPI
-       (such as MIT Kerberos).
+           By default ``pip install requests-ecp`` does not bundle
+           Kerberos auth support.
+           This is provided by the
+           `requests-gssapi <https://github.com/pythongssapi/requests-gssapi>`__
+           package, which in turn relies on a working installation of GSSAPI
+           (such as MIT Kerberos).
 
-       The ``requests-ecp[kerberos]`` extra can be used to automatically
-       include ``requests-gssapi``:
+           The ``requests-ecp[kerberos]`` extra can be used to automatically
+           include ``requests-gssapi``:
 
-       .. code-block:: shell
+           .. code-block:: shell
 
-           python -m pip install requests-ecp[kerberos]
+               python -m pip install requests-ecp[kerberos]
 
-       If you need Kerberos auth, and need to install GSSAPI itself on your
-       system, it is recommended that you
-       **use Conda to install `requests-ecp`**.
+           If you need Kerberos auth, and need to install GSSAPI itself on your
+           system, it is recommended that you
+           **use Conda to install `requests-ecp`**.
 
-.. tabbed:: Scientific Linux
+    .. tab-item:: Scientific Linux
 
-   .. code-block:: bash
+       .. code-block:: bash
 
-       yum install python3-requests-ecp
+           yum install python3-requests-ecp
 
-   See the IGWN Computing Guide software repositories entries for
-   `Scientific Linux 7
-   <https://computing.docs.ligo.org/guide/software/sl7/>`__
-   or
-   `Rocky Linux 8 <https://computing.docs.ligo.org/guide/software/rl8/>`__
-   for instructions on how to configure the required IGWN Yum repositories.
+       See the IGWN Computing Guide software repositories entries for
+       `Scientific Linux 7
+       <https://computing.docs.ligo.org/guide/software/sl7/>`__
+       or
+       `Rocky Linux 8 <https://computing.docs.ligo.org/guide/software/rl8/>`__
+       for instructions on how to configure the required IGWN Yum repositories.
 
 ==============================
 ``requests-ecp`` documentation

--- a/docs/rtd-environment.yml
+++ b/docs/rtd-environment.yml
@@ -13,7 +13,7 @@ dependencies:
   # tests
   - requests-mock>=1.5.0
   # docs
+  - furo
   - sphinx
-  - sphinx_rtd_theme
   - sphinx-tabs
   - sphinx-automodapi

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,5 +52,5 @@ docs =
 	furo
 	sphinx
 	sphinx-argparse
+	sphinx-design
 	sphinx_automodapi
-	sphinx-panels

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,8 +49,8 @@ tests =
 	pytest-cov
 	requests-mock >= 1.5.0
 docs =
+	furo
 	sphinx
 	sphinx-argparse
 	sphinx_automodapi
 	sphinx-panels
-	sphinx_rtd_theme


### PR DESCRIPTION
This PR updates the sphinx documentation to use the furo theme, and to use `sphinx-design` instead of `sphinx-panels`.