### PR TITLE
Avoid corrupted sphinx-automodapi in RTD cache

### DIFF
--- a/docs/rtd-environment.yml
+++ b/docs/rtd-environment.yml
@@ -16,4 +16,4 @@ dependencies:
   - furo
   - sphinx
   - sphinx-tabs
-  - sphinx-automodapi
+  - sphinx-automodapi !=0.17.0


### PR DESCRIPTION
This PR patches the RTD conda environment file to avoid the version of sphinx-automodapi that appears to be corrupt in the RTD package cache (I have no idea how to clear the cache, so this is a hacky workaround).